### PR TITLE
Hide the secret token for production app

### DIFF
--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -4,4 +4,4 @@
 # If you change this key, all old signed cookies will become invalid!
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
-Makeitpersonal::Application.config.secret_token = '87f4bae8fa9d6c16c94972c422f1dcee091d3f32a37ed497777db43c5bab9307b7f794fcfb86c436b4faa5849e363b631adcf8c78824180b4c767e4d0115b4f4'
+Makeitpersonal::Application.config.secret_token = ENV['secret'] || 'development_token'


### PR DESCRIPTION
``` bash
heroku config:set secret=`rake secret`
```

Let's not be SQL-injectable

http://blog.phusion.nl/2013/01/03/rails-sql-injection-vulnerability-hold-your-horses-here-are-the-facts
